### PR TITLE
Tweaking and fine-tuning.

### DIFF
--- a/OpenUserCSSDeepDark.user.css
+++ b/OpenUserCSSDeepDark.user.css
@@ -665,13 +665,13 @@
 		color: var(--main-text) !important;
 		margin-bottom: 30px !important;
 	}
-	.button.is-grey-light
+	.button.is-grey-light, .button.is-grey-lighter
 	{
 		background-color: var(--main-background) !important;
 		border-color: transparent !important;
 		color: var(--main-text) !important;
 	}
-	.button.is-grey-light.is-hovered, .button.is-grey-light:hover
+	.button.is-grey-light.is-hovered, .button.is-grey-light:hover, .button.is-grey-lighter:hover
 	{
 		filter: brightness(120%) !important;
 	}

--- a/OpenUserCSSDeepDark.user.css
+++ b/OpenUserCSSDeepDark.user.css
@@ -153,6 +153,14 @@
 		/*Notice from Breeze Dark*/
 		--notice: #FDBC4B;
 
+		/* Categories */
+		--general: #34495e;
+		--theme-dev: #2980b9;
+		--open-ucss: #60459f;
+		--theme-req: #7f8c8d;
+		--stylus: #1abc9c;
+		--cat-icon: #e3e3e3;
+
 		/*DeepDark colors*/
 		/*
 		--main-color: #00adee;
@@ -1353,6 +1361,51 @@
 	.listview.lv-bordered .lv-item
 	{
 		border-color: var(--main-background) !important;
+	}
+	li.row:nth-child(1) > div:nth-child(2) > div:nth-child(1)
+	{
+		background: var(--general) !important;
+		color: var(--cat-icon) !important;
+	}
+	li.row:nth-child(1) > div:nth-child(5) > div:nth-child(1)
+	{
+		border-color: var(--general) !important;
+	}
+	li.row:nth-child(2) > div:nth-child(2) > div:nth-child(1)
+	{
+		background: var(--theme-dev) !important;
+		color: var(--cat-icon) !important;
+	}
+	li.row:nth-child(2) > div:nth-child(5) > div:nth-child(1)
+	{
+		border-color: var(--theme-dev) !important;
+	}
+	li.row:nth-child(3) > div:nth-child(2) > div:nth-child(1)
+	{
+		background: var(--open-ucss) !important;
+		color: var(--cat-icon) !important;
+	}
+	li.row:nth-child(3) > div:nth-child(5) > div:nth-child(1)
+	{
+		border-color: var(--open-ucss) !important;
+	}
+	li.row:nth-child(4) > div:nth-child(2) > div:nth-child(1)
+	{
+		background: var(--theme-req)  !important;
+		color: var(--cat-icon) !important;
+	}
+	li.row:nth-child(4) > div:nth-child(5) > div:nth-child(1)
+	{
+		border-color: var(--theme-req)  !important;
+	}
+	li.row:nth-child(5) > div:nth-child(2) > div:nth-child(1)
+	{
+		background: var(--stylus) !important;
+		color: var(--cat-icon) !important;
+	}
+	li.row:nth-child(5) > div:nth-child(5) > div:nth-child(1)
+	{
+		border-color: var(--stylus) !important;
 	}
 
 	/*Panels*/

--- a/OpenUserCSSDeepDark.user.css
+++ b/OpenUserCSSDeepDark.user.css
@@ -1027,11 +1027,11 @@
 	}
 	.button.is-patreon .ouc-responsive-image-wrapper
 	{
-		filter: invert(100%) hue-rotate(180deg) contrast(25%) brightness(170%) !important;
+		filter: invert(100%) hue-rotate(180deg) contrast(30%) brightness(190%) !important;
 	}
 	.button.is-paypal .ouc-responsive-image-wrapper
 	{
-		filter: invert(100%) hue-rotate(180deg) brightness(120%) !important;
+		filter: invert(100%) hue-rotate(180deg) !important;
 	}
 	.button.is-paypal:hover, .button.is-patreon:hover
 	{

--- a/OpenUserCSSDeepDark.user.css
+++ b/OpenUserCSSDeepDark.user.css
@@ -663,7 +663,9 @@
 		background: var(--main-color) !important;
 		border-color: transparent !important;
 		color: var(--main-text) !important;
-		margin-bottom: 30px !important;
+		/*margin-bottom: 30px !important;*/
+		/*Im disabling this because it makes no sense
+		and adds margins where none exists in various elements.*/
 	}
 	.button.is-grey-light, .button.is-grey-lighter
 	{

--- a/OpenUserCSSDeepDark.user.css
+++ b/OpenUserCSSDeepDark.user.css
@@ -1242,6 +1242,11 @@
 	}
 
 	/*Chat*/
+	/* title of chats modal is not blue */
+	.ui-draggable-handle > h4
+	{
+		color: var(--main-text) !important;
+	}
 	.chat-content, .modal-content
 	{
 		background: var(--second-background) !important;

--- a/OpenUserCSSDeepDark.user.css
+++ b/OpenUserCSSDeepDark.user.css
@@ -653,7 +653,7 @@
 	{
 		filter: brightness(110%) !important;
 	}
-	/* style boder left in theme settings bounding boxes */
+	/* style border left in theme settings bounding boxes */
 	.has-brand-line-left
 	{
 		border-left: 5px solid var(--main-color) !important;
@@ -1030,7 +1030,7 @@
 		background: var(--hover-background) !important;
 	}
 
-	/*Sned issues*/
+	/*Send issues*/
 	.sentry-error-embed
 	{
 		background: var(--hover-background) !important;

--- a/OpenUserCSSDeepDark.user.css
+++ b/OpenUserCSSDeepDark.user.css
@@ -2,7 +2,7 @@
 @name OpenUserCSS DeepDark
 @namespace github.com/OpenUserCSS/OpenUserCSS-DeepDark
 @homepageURL https://github.com/OpenUserCSS/OpenUserCSS-DeepDark
-@version 1.4.6
+@version 1.4.7
 @updateURL https://raw.githubusercontent.com/OpenUserCSS/OpenUserCSS-DeepDark/master/OpenUserCSSDeepDark.user.css
 @description Host your code in the dark. May the dark be kinder on thine eyes. (openusercss.org dark theme)
 @author RaitaroH
@@ -132,7 +132,7 @@
 
 /*GNU General Public License v3.0*/
 
-/*1.4.6*/
+/*1.4.7*/
 
 	/*Main color variables*/
 	:root

--- a/OpenUserCSSDeepDark.user.css
+++ b/OpenUserCSSDeepDark.user.css
@@ -538,14 +538,15 @@
 	{
 		color: var(--dimmer-text) !important;
 	}
+	/* generic hr line */
 	hr
 	{
 		background: var(--hover-background) !important;
 	}
-	/* card content hr*/
+	/* user card .card-content.is-brand-primary content hr*/
 	.is-8 hr
 	{
-		background: var(--main-text) !important;
+		background: var(--hover-background) !important;
 	}
 	.control.has-icons-left .icon, .control.has-icons-right .icon
 	{
@@ -603,6 +604,11 @@
 	.card-footer-item, .card-footer
 	{
 		border-color: transparent !important;
+	}
+	.card-content.is-brand-primary
+	{
+		background: var(--main-background) !important;
+		color: var(--main-text) !important;
 	}
 	/*Buttons*/
 	.is-brand-primary

--- a/OpenUserCSSDeepDark.user.css
+++ b/OpenUserCSSDeepDark.user.css
@@ -404,6 +404,19 @@
 	{
 		color: var(--main-text) !important;
 	}
+	/* this styles the bio preview pane below and the theme submission preview pane
+	Im taking inspiration from the post submission preview well
+	commit d021dc9 or https://git.io/vhKn1 */
+	.columns > div > div > div:nth-child(4), .box.is-minheight-description
+	{
+		background: var(--main-background) !important;
+		color: var(--main-text) !important;
+		opacity: .75;
+	}
+	.content p, .box.is-minheight-description p
+	{
+		color: var(--dimmer-text) !important;
+	}
 
 	/* help page */
 	.box.is-warning

--- a/OpenUserCSSDeepDark.user.css
+++ b/OpenUserCSSDeepDark.user.css
@@ -709,20 +709,34 @@
 		color: var(--main-text) !important;
 	}
 
-	/* Ratings  fixed 1.0.0 */
-	.vue-star-rating-star stop[stop-color="#ffd055"], .vue-star-rating-star stop[stop-color="#ffd055"]
+	/* Ratings fixed 1.1.0
+	first selector is actual rating action, second selector is the main page overview.
+	for the time being the unstarred background has to be light not dark because
+	otherwise this looks all uneven, ugly and the contrast is poor for good visibility.*/
+	.vue-star-rating-star stop[stop-color="#ffd055"],
+	.vue-star-rating-star stop[stop-color="#FFB450"]
 	{
 		stop-color: var(--main-color) !important;
 	}
-	.vue-star-rating-star stop[stop-color="#d8d8d8"], .vue-star-rating-star stop[stop-color="#d8d8d8"]
+	.vue-star-rating-star stop[stop-color="#d8d8d8"],
+	.vue-star-rating-star stop[stop-color="#FFFFFF"]
 	{
-		stop-color: var(--main-background) !important;
+		stop-color: var(--dimmer-text) !important;
 	}
-	.vue-star-rating-star polygon[stroke="#999"], .vue-star-rating-star polygon[stroke="#999"]
+	.vue-star-rating-star polygon[stroke="#fff"]
 	{
-		stroke: var(--main-background) !important;
+		stroke: var(--dimmer-text) !important;
+		stroke-width: 0px !important; /* this is a hack to make sure the stars dont look lobsided */
 	}
-
+	.vue-star-rating-star polygon[stroke="#FFFFFF"]
+	{
+		stroke: var(--dimmer-text) !important;
+	}
+	.vue-star-rating-star polygon[stroke="#999"]
+	{
+		stroke: var(--dimmer-text) !important;
+		stroke-width: 1px !important; /* this is a hack to make sure the stars dont look lobsided */
+	}
 	/*Profile*/
 	.tile.is-parent h2, h4
 	{

--- a/OpenUserCSSDeepDark.user.css
+++ b/OpenUserCSSDeepDark.user.css
@@ -388,6 +388,10 @@
 		background-color: var(--warning-disable-all) !important;
 		color: var(--main-text) !important;
 	}
+	.notification.is-danger p
+	{
+		color: var(--main-text) !important;
+	}
 	/* target section hr directly */
 	.section hr
 	{

--- a/OpenUserCSSDeepDark.user.css
+++ b/OpenUserCSSDeepDark.user.css
@@ -783,21 +783,48 @@
 	{
 		color: var(--main-text) !important;
 	}
-	.table tr:nth-child(odd)
-	{
-		background-color: var(--main-background) !important;
-		color: var(--main-text) !important;
-	}
-	.table tr:nth-child(even)
+	.table
 	{
 		background-color: var(--second-background) !important;
 		color: var(--main-text) !important;
 	}
-	.table tr:nth-child(odd):hover, .table tr:nth-child(even):hover
+	.table b, .table:hover b
+	{
+		color: var(--main-text) !important;
+	}
+	.table tr:nth-child(even)
+	{
+		background-color: var(--main-background) !important;
+		color: var(--main-text) !important;
+	}
+	.table td
+	{
+		border: 1px solid var(--hover-background) !important;
+	}
+	.table tr
+	{
+		background: var(--second-background) !important;
+	}
+	.table tr:nth-child(even)
+	{
+		background: var(--main-background) !important;
+	}
+
+	.table.is-marginless tr:nth-child(odd)
+	{
+		background-color: var(--main-background) !important;
+		color: var(--main-text) !important;
+	}
+	.table.is-marginless tr:nth-child(even)
+	{
+		background-color: var(--second-background) !important;
+		color: var(--main-text) !important;
+	}
+	.table.is-marginless tr:nth-child(odd):hover, .table.is-marginless tr:nth-child(even):hover
 	{
 		background: var(--hover-background) !important;
 	}
-	.table td, .table th
+	.table.is-marginless td, .table.is-marginless th
 	{
 		border: 1px solid var(--hover-background) !important;
 	}

--- a/OpenUserCSSDeepDark.user.css
+++ b/OpenUserCSSDeepDark.user.css
@@ -1392,6 +1392,13 @@
 	}
 
 	/*Unread*/
+	/* fixes alert info specifically in chats (it is only visible with more than one chat target active)*/
+	.chats-full .alert-info
+	{
+		background: var(--hover-background) !important;
+		color: var(--main-text) !important;
+		border-color: var(--hover-background) !important;
+	}
 	.alert-info
 	{
 		color: var(--main-color) !important;

--- a/OpenUserCSSDeepDark.user.css
+++ b/OpenUserCSSDeepDark.user.css
@@ -917,6 +917,11 @@
 	{
 		color: var(--main-text) !important;
 	}
+	/* fix: hide text/icon when loading*/
+	.tile.is-vertical .button.is-primary.is-loading p, .tile.is-vertical .button.is-primary.is-loading .fa-user-plus
+	{
+		display: none !important;
+	}
 	.alert.alert-danger, .alert.alert-danger p, .alert.alert-danger strong
 	{
 		background: var(--warning-disable-all) !important;

--- a/OpenUserCSSDeepDark.user.css
+++ b/OpenUserCSSDeepDark.user.css
@@ -388,7 +388,7 @@
 		background-color: var(--warning-disable-all) !important;
 		color: var(--main-text) !important;
 	}
-	.notification.is-danger p
+	.notification.is-danger p, .notification.is-danger a
 	{
 		color: var(--main-text) !important;
 	}


### PR DESCRIPTION
@RaitaroH https://github.com/OpenUserCSS/OpenUserCSS-DeepDark/commit/1334708b3ce1d2e4cfb05e2e1b23164326ca1fd6 addresses your comments at https://github.com/OpenUserCSS/OpenUserCSS-DeepDark/pull/21#issuecomment-396814566

Happy?

2382fa0 is also been bugging me, because by default this is what happens, details, its all about details.

2adf11f the ratings pay attention now. I would love if we could fix #22 for one, but it cant be fixed by CSS and in addition the rating is rendered over the screenshot of the theme (if it has one) and this means it could be ANY COLOR so the ratings has to try to be visible over the most possible scenarios.

This iMO is a design flaw, it would be better if ratings got displayed before user name but it does not.

So this is how it is, looks quite good considering.

![rating](https://user-images.githubusercontent.com/31389848/41372541-8786fb0c-6f45-11e8-898c-929a77c27eb9.gif)

6d6c06d categories: see discussion on the other topic, thoughts?

![screenshot-2018-6-13 openusercss](https://user-images.githubusercontent.com/31389848/41382101-8c428d7e-6f62-11e8-9228-4da8abb42ef3.png)

The rest is small fixes and tweaks to make things more consistent.

As for our discussion in https://github.com/RaitaroH/Stylus-DeepDark/pull/14#issuecomment-396965562 regarding the categories, I'll leave that for another time and do please provide feedback on that.

Cheers.


 
