### PR TITLE
OpenUserCSS API 1.3.1 vavavoom almost

### DIFF
--- a/OpenUserCSSDeepDark.user.css
+++ b/OpenUserCSSDeepDark.user.css
@@ -769,6 +769,13 @@
 		stroke: var(--dimmer-text) !important;
 		stroke-width: 1px !important; /* this is a hack to make sure the stars dont look lobsided */
 	}
+	/* Pull rating stars down
+	see https://github.com/OpenUserCSS/openusercss.org/issues/104 */
+	.ouc-screenshot-overlay .is-pulled-right.vue-star-rating
+	{
+		margin-top: 180px !important;
+	}
+
 	/*Profile*/
 	.tile.is-parent h2, h4
 	{

--- a/OpenUserCSSDeepDark.user.css
+++ b/OpenUserCSSDeepDark.user.css
@@ -2,7 +2,7 @@
 @name OpenUserCSS DeepDark
 @namespace github.com/OpenUserCSS/OpenUserCSS-DeepDark
 @homepageURL https://github.com/OpenUserCSS/OpenUserCSS-DeepDark
-@version 1.4.8
+@version 1.4.9
 @updateURL https://raw.githubusercontent.com/OpenUserCSS/OpenUserCSS-DeepDark/master/OpenUserCSSDeepDark.user.css
 @description Host your code in the dark. May the dark be kinder on thine eyes. (openusercss.org dark theme)
 @author RaitaroH
@@ -132,7 +132,7 @@
 
 /*GNU General Public License v3.0*/
 
-/*1.4.8*/
+/*1.4.9*/
 
 	/*Main color variables*/
 	:root

--- a/OpenUserCSSDeepDark.user.css
+++ b/OpenUserCSSDeepDark.user.css
@@ -995,7 +995,7 @@
 	{
 		background: var(--hover-background) !important;
 	}
-	.ouc-editor
+	.ouc-editor.ace_editor
 	{
 		background: var(--main-background) !important;
 		border-color: var(--second-background) !important;
@@ -1009,6 +1009,15 @@
 	{
 		border-color: var(--main-color) !important;
 		border-left-width: 3px !important;
+	}
+	.ace_editor.ace_focus
+	{
+		border: 2px solid var(--main-color) !important;
+	}
+	.ace_comment
+	{
+		font-style: italic !important;
+		color: var(--dimmer-text) !important;
 	}
 	/*Buttons*/
 	.has-bottom-margin .button.is-primary, .tile.is-6 .button.is-primary,

--- a/OpenUserCSSDeepDark.user.css
+++ b/OpenUserCSSDeepDark.user.css
@@ -1500,6 +1500,7 @@
 	{
 		color: var(--main-color) !important;
 		background: var(--hover-background) !important;
+		border-color: var(--hover-background) !important;
 	}
 	.alert-warning
 	{

--- a/OpenUserCSSDeepDark.user.css
+++ b/OpenUserCSSDeepDark.user.css
@@ -622,6 +622,22 @@
 		background: var(--main-background) !important;
 		color: var(--main-text) !important;
 	}
+	/* Style generic card background
+	see  https://github.com/OpenUserCSS/openusercss.org/issues/103 */
+	.ouc-responsive-image.-img-main-bg-x640-png
+	{
+		background:
+			repeating-linear-gradient(
+				45deg,
+				transparent,
+				transparent 10px,
+				var(--hover-background) 10px,
+				var(--main-background) 80px),
+			linear-gradient(
+				to bottom,
+				var(--hover-background),
+				var(--main-background)) !important;
+	}
 	/*Buttons*/
 	.is-brand-primary, .button.is-primary.is-backgroundless
 	{

--- a/OpenUserCSSDeepDark.user.css
+++ b/OpenUserCSSDeepDark.user.css
@@ -991,7 +991,8 @@
 		border-color: var(--second-background) !important;
 		color: var(--main-text) !important;
 	}
-	.ace_folding-enabled > .ace_gutter-cell, .ace-tm .ace_marker-layer .ace_active-line, .ace-tm .ace_marker-layer .ace_selection
+	.ace_folding-enabled > .ace_gutter-cell, .ace-tm .ace_marker-layer .ace_active-line,
+	.ace-tm .ace_marker-layer .ace_selection
 	{
 		background: var(--hover-background) !important;
 	}
@@ -1021,7 +1022,7 @@
 	}
 	/*Buttons*/
 	.has-bottom-margin .button.is-primary, .tile.is-6 .button.is-primary,
-	.is-marginless[is-pulled-right="is-pulled-right"]  .button.is-primary
+	.is-marginless[is-pulled-right="is-pulled-right"] .button.is-primary
 	{
 		background: var(--main-color) !important;
 		color: var(--main-text) !important;
@@ -1029,7 +1030,7 @@
 		opacity: 1 !important;
 	}
 	.has-bottom-margin .button.is-primary:hover, .tile.is-6 .button.is-primary:hover,
-	.is-marginless[is-pulled-right="is-pulled-right"]  .button.is-primary:hover
+	.is-marginless[is-pulled-right="is-pulled-right"] .button.is-primary:hover
 	{
 		filter: brightness(110%);
 	}


### PR DESCRIPTION
Worthwhile mentions:

OK this 1.3.1 is buggy as hell but it added the ability to target the generic card screenshot, this works well and allows a pure CSS solution that matches OpenUserCSS Dark theme :+1: :joy_cat: thx @DecentM  for adding this so quickly.

Im also happy that were able to target the card ratings and move them below the screenshot, this is good news because the user uploaded screenshot can be many colors/backgrounds that make the rating hard to read.  See https://github.com/OpenUserCSS/openusercss.org/issues/104

So here is d1437b0 and ca0506d which results in this: (from https://github.com/OpenUserCSS/openusercss.org/issues/104#issuecomment-397485434)

![screenshot-2018-6-15 openusercss](https://user-images.githubusercontent.com/31389848/41444651-5668bb58-703c-11e8-941e-78f145771e64.png)

The remainder is a small border fix as I stumbled on yet another alert-info without, there wont be any more surprises in this area.
Also added focus to Ace editor and a comment styling but Ace editor is buggy and I just dont like it anyway. CodeMirror is WAY better and FTW opened https://github.com/OpenUserCSS/openusercss.org/issues/108

So @RaitaroH you like?

