### PR TITLE
fix ratings on search page too + fix search button text while loading

### DIFF
--- a/OpenUserCSSDeepDark.user.css
+++ b/OpenUserCSSDeepDark.user.css
@@ -783,7 +783,7 @@
 	see https://github.com/OpenUserCSS/openusercss.org/issues/104 */
 	.ouc-screenshot-overlay .is-pulled-right.vue-star-rating
 	{
-		margin-top: 180px !important;
+		margin-top: 125px !important;
 	}
 
 	/*Profile*/

--- a/OpenUserCSSDeepDark.user.css
+++ b/OpenUserCSSDeepDark.user.css
@@ -2,7 +2,7 @@
 @name OpenUserCSS DeepDark
 @namespace github.com/OpenUserCSS/OpenUserCSS-DeepDark
 @homepageURL https://github.com/OpenUserCSS/OpenUserCSS-DeepDark
-@version 1.5.1
+@version 1.5.2
 @updateURL https://raw.githubusercontent.com/OpenUserCSS/OpenUserCSS-DeepDark/master/OpenUserCSSDeepDark.user.css
 @description Host your code in the dark. May the dark be kinder on thine eyes. (openusercss.org dark theme)
 @author RaitaroH
@@ -132,7 +132,7 @@
 
 /*GNU General Public License v3.0*/
 
-/*1.5.1*/
+/*1.5.2*/
 
 	/*Main color variables*/
 	:root

--- a/OpenUserCSSDeepDark.user.css
+++ b/OpenUserCSSDeepDark.user.css
@@ -934,6 +934,11 @@
 	{
 		filter: brightness(110%);
 	}
+	/* fix text on button shows when search animation overlays*/
+	.section .button.is-primary.is-pulled-right.is-loading
+	{
+		color: transparent !important;
+	}
 	/*Notification List */
 	.notification.is-primary
 	{


### PR DESCRIPTION
Theres no before and after gif, just after (before rating showed outside the box on search page results.) for https://github.com/OpenUserCSS/OpenUserCSS-DeepDark/pull/28/commits/66c16161926d418b7ab7b9d1e08aa71db3fcb43b

![ratings](https://user-images.githubusercontent.com/31389848/41720727-d945d168-755b-11e8-9ab7-e0623cd797d5.gif)

for https://github.com/OpenUserCSS/OpenUserCSS-DeepDark/pull/28/commits/1271d8816d05e91d6b5a78a29388e4b24e0212a0

![search](https://user-images.githubusercontent.com/31389848/41722397-59296aee-7560-11e8-9dab-a570cb521b24.gif)

<s>Im trying to push a tag for this project at 1.5.2 as well, never done that in a PR so bare with me.</s>

You cant push tags in pull requests, pff :)